### PR TITLE
Update 5.Containers-Azure.md

### DIFF
--- a/Docker/5.Containers-Azure.md
+++ b/Docker/5.Containers-Azure.md
@@ -9,13 +9,13 @@ az group create -n acidemo -l westeurope
 Create our container group
 
 ```txt
-az container create -g acidemo  --name mycontainer --image shahiddev/k8s:1.0 --dns-name-label aci-demo --ports 80
+az container create -g acidemo  --name mycontainer --image shahiddev/k8s:1.0 --dns-name-label acidemo --ports 80
 ```
 
 We can run windows container too by specifying the `--os-type` flag
 
 ```txt
-az container create -g acidemo  --name wincontainer --image microsoft/iis --dns-name-label winaci-demo --ports 80 --os-type windows
+az container create -g acidemo  --name wincontainer --image microsoft/iis --dns-name-label winacidemo --ports 80 --os-type windows
 ```
 
 Stop will stop the containers and billing for them


### PR DESCRIPTION
Reason: 
The DNS name label 'aci-demo' in container group 'mycontainer' not available. Try using a different label.
removing hyphens in --dns-name-label to avoid problem.